### PR TITLE
Do not throw on PSGallery

### DIFF
--- a/DSCClassResources/PowershellRepository/PowershellRepository.psm1
+++ b/DSCClassResources/PowershellRepository/PowershellRepository.psm1
@@ -133,7 +133,7 @@ class PowershellRepository
         {
             if ($Count -ne 1)
             {
-                if (-not $this.SourceLocation)
+                if (-not $this.SourceLocation -and ($this.Name -ne "PSGallery"))
                 {
                     throw "SourceLocation is required when the PSRepository does not currently exist."
                 }

--- a/Tests/Unit/PowershellRepository.tests.ps1
+++ b/Tests/Unit/PowershellRepository.tests.ps1
@@ -153,6 +153,16 @@ try
 
                         Assert-MockCalled -CommandName Get-PSRepository -Scope It -Times 1
                     }
+                    
+                    It 'Should not throw when PSGallery does not exist and SourceLocation unspecified' {
+                        $PowershellRepository.Name = "PSGallery"
+                        
+                        Mock Get-PSRepository {}
+
+                        { $PowershellRepository.Test() } | Should not throw
+
+                        Assert-MockCalled -CommandName Get-PSRepository -Scope It -Times 1
+                    }                    
 
                     It 'Should return $false when InstallationPolicy is incorrect' {
                         $PowershellRepository.Ensure = "Present"


### PR DESCRIPTION
#### Pull Request (PR) description
Do not throw when PSGallery does not exist and SourceLocation is unspecified.

#### This Pull Request (PR) fixes the following issues
None

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
